### PR TITLE
Improve efficiency

### DIFF
--- a/src/algebra.jl
+++ b/src/algebra.jl
@@ -16,11 +16,12 @@ Arguments can be of arbitrary size and dimension.
 """
 function ⊗(t1::Tensor{T}, t2::Tensor{S}) where {T,S}
     res = Array{promote_type(T, S)}(undef, size(t1)..., size(t2)...)
-    inds1, inds2 = CartesianIndices(t1), CartesianIndices(t2)
 
-    # FIXME: way to many allocs here, probably bad index usage
-    for i in eachindex(t1), j in eachindex(t2)
-        @inbounds res[inds1[i], inds2[j]] = t1.data[i] * t2.data[j]
+    j, k = 1, 1
+    for i in eachindex(res)
+        @inbounds res[i] = t1.data[j] * t2.data[k]
+        k += j == length(t1) ? 1 : 0
+        j = j % length(t1) + 1
     end
 
     return Tensor(res)

--- a/src/algebra.jl
+++ b/src/algebra.jl
@@ -102,7 +102,7 @@ function contract(t::Tensor, d1::Integer, d2::Integer)
     res = Array{eltype(t)}(undef, size(a)[3:ndims(a)])
     inds = CartesianIndices(res)
 
-    # NOTE: replacing the cartesian indexing by on the fly linear indexing hurts performance
+    # NOTE: replacing the cartesian indexing by on-the-fly linear indexing hurts performance
     for i in eachindex(res)
         @inbounds res[i] = sum(a[j, j, inds[i]] for j in axes(a, 1))
     end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -89,3 +89,5 @@ Base.argmin(t::Tensor; kwargs...) = argmin(t.data; kwargs...)
 
 Base.findmax(t::Tensor; kwargs...) = (maximum(t; kwargs...), argmax(t; kwargs...))
 Base.findmin(t::Tensor; kwargs...) = (minimum(t; kwargs...), argmin(t; kwargs...))
+
+Base.conj(t::Tensor) = Tensor(conj(t.data))

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -207,7 +207,7 @@ end
     @test extrema(t1; dims=1) == (Tensor([1 2]), Tensor([3 4]))
 
     # NOTE: similar to extrema, this functions does not return a tensor of cartesian indices
-    # when assign the 'dims' keyword but rather an 'Array{CartesianIndices}'
+    # when assigning the 'dims' keyword but rather an 'Array{CartesianIndices}'
     @test argmax(t1) == CartesianIndex(2, 2)
     @test argmax(t1; dims=1) == [CartesianIndex(2, 1) CartesianIndex(2, 2)]
     @test argmin(t1) == CartesianIndex(1, 1)
@@ -221,4 +221,9 @@ end
         Tensor(reshape([1, 3], 2, 1)),
         reshape([CartesianIndex(1, 1), CartesianIndex(2, 1)], 2, 1),
     )
+
+    t2 = Tensor([1 - im 3; -2im 2 + 3im])
+    @test conj(t2) == Tensor([1 + im 3; 2im 2 - 3im])
+    t3 = Tensor(rand(4, 7, 5))
+    @test conj(t3) == t3
 end

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -222,8 +222,8 @@ end
         reshape([CartesianIndex(1, 1), CartesianIndex(2, 1)], 2, 1),
     )
 
-    t2 = Tensor([1 - im 3; -2im 2 + 3im])
-    @test conj(t2) == Tensor([1 + im 3; 2im 2 - 3im])
+    t2 = Tensor([1-im 3; -2im 2+3im])
+    @test conj(t2) == Tensor([1+im 3; 2im 2-3im])
     t3 = Tensor(rand(4, 7, 5))
     @test conj(t3) == t3
 end


### PR DESCRIPTION
Mainly improved indexing behaviour of the algebraic tensor operations which were straight-forward but pretty wasteful with allocs.